### PR TITLE
Allow custom headers for request

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ As of the [Marathon sources](https://github.com/mesosphere/marathon/blob/master/
  * `unknown_instance_terminated_event`
  * `instance_health_changed_event`
  * `framework_message_event`
- 
+
 ### Internal events
 
 The Marathon Event Bus Client itself emits the following events:
- 
+
  * `subscribed`: Is emitted after a successful subscription to the Marathon Event Bus.
  * `unsubscribed`: Is emitted after `unsubscribe()` is called.
  * `error`: Is emitted in case of internal or upstream errors.
-   
+
 ## Using the client
 
 ### Options
@@ -63,8 +63,10 @@ You can specify the following properties when instantiating the Marathon Event B
 
  * `marathonHost`: The Marathon base URL. Default is `master.mesos`.
  * `marathonPort`: The Marathon port. Default is `8080`.
- * `marathonProtocol`: The Marathon protocol (`http` or `https`). Default is `http`. 
+ * `marathonProtocol`: The Marathon protocol (`http` or `https`). Default is `http`.
  * `marathonUri`: The relative path where the Marathon Event Bus endpoint can be found. Default is `/v2/events`.
+ * `marathonHeaders`: If you are using Marathon from outside you can add options to the request. Default is an empty object `{}`.
+ Example: `marathonHeaders = { headers: {'Authorization': 'token=MARATHON_AUTH_TOKEN'}`
  * `eventTypes`: An `array` of event types emitted by Marathon (see above for a list). Default is `["deployment_info", "deployment_success", "deployment_failed"]`.
  * `handlers`: A map object consisting of handler functions for the individual Marathon events. See [below](#handler-functions) for an explanation. No defaults.
 
@@ -74,7 +76,7 @@ The Marathon Event Bus Client only exposes the `subscribe()` and the `unsubscrib
 
 ### Handler functions
 
-The custom event handler functions can be configured by setting a map object as `handlers` property during the instantiation. Each map object's property represents a event handling function. The property name needs to match on of the Marathon event types from the [list of known Marathon events](#known-marathon-events). 
+The custom event handler functions can be configured by setting a map object as `handlers` property during the instantiation. Each map object's property represents a event handling function. The property name needs to match on of the Marathon event types from the [list of known Marathon events](#known-marathon-events).
 
 This is an example `handlers` map object:
 
@@ -96,7 +98,7 @@ The function arguments are:
 
 ### Example code
 
-For a complete example, have a look at [examples/example.js](examples/example.js). Also, for a "real-life example", you can refer to [marathon-slack](https://github.com/tobilg/marathon-slack). 
+For a complete example, have a look at [examples/example.js](examples/example.js). Also, for a "real-life example", you can refer to [marathon-slack](https://github.com/tobilg/marathon-slack).
 
 ```javascript
 // Use the MarathonEventBusClient
@@ -133,7 +135,7 @@ const mebc = new MarathonEventBusClient({
 mebc.on("connected", function () {
 
     console.log("Subscribed to the Marathon Event Bus");
-    
+
     // For example purposes: Log all events we receive
     // In real-world usage, you should define what needs to be done when
     // receiving specific events in the `handlers` property for each event type

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can specify the following properties when instantiating the Marathon Event B
  * `marathonProtocol`: The Marathon protocol (`http` or `https`). Default is `http`.
  * `marathonUri`: The relative path where the Marathon Event Bus endpoint can be found. Default is `/v2/events`.
  * `marathonHeaders`: If you are using Marathon from outside you can add options to the request. Default is an empty object `{}`.
- Example: `marathonHeaders = {'Authorization': 'token=MARATHON_AUTH_TOKEN', 'Content-Type': 'application/json'}`
+ Example: `marathonHeaders = {'Authorization': 'token=API_ACCESS_TOKEN', 'Content-Type': 'application/json'}`
  * `eventTypes`: An `array` of event types emitted by Marathon (see above for a list). Default is `["deployment_info", "deployment_success", "deployment_failed"]`.
  * `handlers`: A map object consisting of handler functions for the individual Marathon events. See [below](#handler-functions) for an explanation. No defaults.
 
@@ -111,7 +111,7 @@ const eventTypes = ["deployment_info", "deployment_success", "deployment_failed"
 const mebc = new MarathonEventBusClient({
     marathonHost: "localhost", // Use SSE test server
     eventTypes: eventTypes,
-    marathonHeaders: {'Authorization': 'token=MARATHON_AUTH_TOKEN'} // if you are using the api outisde the cluster
+    marathonHeaders: {'Authorization': 'token=API_ACCESS_TOKEN'} // if you are using the api outisde the cluster
     handlers: { // Specify the custom event handlers
         "deployment_info": function (name, data) {
             console.log("Custom handler for " + name);

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can specify the following properties when instantiating the Marathon Event B
  * `marathonProtocol`: The Marathon protocol (`http` or `https`). Default is `http`.
  * `marathonUri`: The relative path where the Marathon Event Bus endpoint can be found. Default is `/v2/events`.
  * `marathonHeaders`: If you are using Marathon from outside you can add options to the request. Default is an empty object `{}`.
- Example: `marathonHeaders = { headers: {'Authorization': 'token=MARATHON_AUTH_TOKEN'}`
+ Example: `marathonHeaders = {'Authorization': 'token=MARATHON_AUTH_TOKEN', 'Content-Type': 'application/json'}`
  * `eventTypes`: An `array` of event types emitted by Marathon (see above for a list). Default is `["deployment_info", "deployment_success", "deployment_failed"]`.
  * `handlers`: A map object consisting of handler functions for the individual Marathon events. See [below](#handler-functions) for an explanation. No defaults.
 
@@ -111,6 +111,7 @@ const eventTypes = ["deployment_info", "deployment_success", "deployment_failed"
 const mebc = new MarathonEventBusClient({
     marathonHost: "localhost", // Use SSE test server
     eventTypes: eventTypes,
+    marathonHeaders: {'Authorization': 'token=MARATHON_AUTH_TOKEN'} // if you are using the api outisde the cluster
     handlers: { // Specify the custom event handlers
         "deployment_info": function (name, data) {
             console.log("Custom handler for " + name);

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can specify the following properties when instantiating the Marathon Event B
  * `marathonPort`: The Marathon port. Default is `8080`.
  * `marathonProtocol`: The Marathon protocol (`http` or `https`). Default is `http`.
  * `marathonUri`: The relative path where the Marathon Event Bus endpoint can be found. Default is `/v2/events`.
- * `marathonHeaders`: If you are using Marathon from outside you can add options to the request. Default is an empty object `{}`.
+ * `marathonHeaders`: Allows you to add headers to Marathon's API requests. Default is an empty object `{}`
  Example: `marathonHeaders = {'Authorization': 'token=API_ACCESS_TOKEN', 'Content-Type': 'application/json'}`
  * `eventTypes`: An `array` of event types emitted by Marathon (see above for a list). Default is `["deployment_info", "deployment_success", "deployment_failed"]`.
  * `handlers`: A map object consisting of handler functions for the individual Marathon events. See [below](#handler-functions) for an explanation. No defaults.

--- a/examples/example.js
+++ b/examples/example.js
@@ -19,7 +19,7 @@ const request = require("request");
 const mebc = new MarathonEventBusClient({
     marathonHost: "localhost", // Use SSE test server
     eventTypes: eventTypes,
-    marathonHeaders: { 'Authorization': 'token=MARATHON_AUTH_TOKEN'}, // if you are using the api outisde the cluster
+    marathonHeaders: { 'Authorization': 'token=API_ACCESS_TOKEN'}, // if you are using the api outisde the cluster
     handlers: { // Specify the custom event handlers
         "deployment_info": function (name, data) {
             console.log("Custom handler for " + name);

--- a/examples/example.js
+++ b/examples/example.js
@@ -19,7 +19,7 @@ const request = require("request");
 const mebc = new MarathonEventBusClient({
     marathonHost: "localhost", // Use SSE test server
     eventTypes: eventTypes,
-    marathonHeaders: { 'Authorization': 'zdasd', 'Content-Type': '', 'Date': '', 'Cookie': ''},
+    marathonHeaders: { 'Authorization': 'token=MARATHON_AUTH_TOKEN'}, // if you are using the api outisde the cluster
     handlers: { // Specify the custom event handlers
         "deployment_info": function (name, data) {
             console.log("Custom handler for " + name);

--- a/examples/example.js
+++ b/examples/example.js
@@ -19,6 +19,7 @@ const request = require("request");
 const mebc = new MarathonEventBusClient({
     marathonHost: "localhost", // Use SSE test server
     eventTypes: eventTypes,
+    marathonHeaders: { 'Authorization': 'zdasd', 'Content-Type': '', 'Date': '', 'Cookie': ''},
     handlers: { // Specify the custom event handlers
         "deployment_info": function (name, data) {
             console.log("Custom handler for " + name);

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -38,7 +38,7 @@ function MarathonEventBusClient (options) {
     self.options.marathonUri = options.marathonUri || "/v2/events";
     /*
      You can add additionals headers
-     {'Authorization': 'token=ACCESS_TOKEN', 'Content-Type': 'application/json'}
+     {'Authorization': 'token=API_ACCESS_TOKEN', 'Content-Type': 'application/json'}
     */
     self.options.marathonHeaders = options.marathonHeaders || {};
 

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -108,10 +108,9 @@ MarathonEventBusClient.prototype.subscribe = function () {
         url = self.options.marathonProtocol + "://" + self.options.marathonHost + ":" + self.options.marathonPort+self.options.marathonUri;
 
     // Allow unauthorized HTTPS requests
-    let eventSourceInitDict = {
-      self.options.marathonHeaders,
-      rejectUnauthorized: false
-    };
+    let eventSourceInitDict = self.options.marathonHeaders;
+
+    eventSourceInitDict.rejectUnauthorized = false;
 
     // Create EventSource for Marathon /v2/events endpoint
     self.es = new EventSource(url, eventSourceInitDict);

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -57,7 +57,7 @@ function MarathonEventBusClient (options) {
         // Just use the deployment events by default, to avoid channel flooding
         self.options.eventTypes = ["deployment_info", "deployment_success", "deployment_failed"];
     }
-
+    // Set custom headers if present
     if (options.marathonHeaders && Object.keys(options.marathonHeaders).length > 0) {
       self.options.marathonHeaders = {};
         Object.keys(options.marathonHeaders).forEach(function (key) {

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -25,6 +25,10 @@ function MarathonEventBusClient (options) {
       "pod_created_event","pod_updated_event", "pod_deleted_event","scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event", "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"
     ];
 
+    self.allowedHeaeders = [
+      'Content-Type', 'Authorization'
+    ];
+
     self.options = {};
 
     // Marathon endpoint discovery
@@ -33,8 +37,8 @@ function MarathonEventBusClient (options) {
     self.options.marathonProtocol = options.marathonProtocol || "http";
     self.options.marathonUri = options.marathonUri || "/v2/events";
     /*
-     Marathon headers if you are using the api from the outside or for test
-     { headers: {'Authorization': 'token=MARATHON_AUTH_TOKEN'}
+     You can add additionals headers
+     {'Authorization': 'token=MARATHON_AUTH_TOKEN', 'Content-Type': 'application/json'}
     */
     self.options.marathonHeaders = options.marathonHeaders || {};
 
@@ -52,6 +56,15 @@ function MarathonEventBusClient (options) {
     } else {
         // Just use the deployment events by default, to avoid channel flooding
         self.options.eventTypes = ["deployment_info", "deployment_success", "deployment_failed"];
+    }
+
+    if (options.marathonHeaders && Object.keys(options.marathonHeaders).length > 0) {
+      self.options.marathonHeaders = {};
+        Object.keys(options.marathonHeaders).forEach(function (key) {
+          if(self.allowedHeaeders.indexOf(key) > -1) {
+            self.options.marathonHeaders[key] = options.marathonHeaders[key];
+          }
+        });
     }
 
     if (self.options.enableConnectionEvent) {

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -21,7 +21,9 @@ function MarathonEventBusClient (options) {
     let self = this;
 
     // See https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/core/event/Events.scala
-    self.allowedEventTypes = ["pod_created_event", "pod_updated_event", "pod_deleted_event", "scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event", "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"];
+    self.allowedEventTypes = [
+      "pod_created_event","pod_updated_event", "pod_deleted_event", "scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event",
+      "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"];
 
     self.options = {};
 
@@ -30,7 +32,12 @@ function MarathonEventBusClient (options) {
     self.options.marathonPort = parseInt(options.marathonPort) || 8080;
     self.options.marathonProtocol = options.marathonProtocol || "http";
     self.options.marathonUri = options.marathonUri || "/v2/events";
-    
+    /*
+     Marathon headers if you are using the api from the outside or for test
+     { headers: {'Authorization': 'token=MARATHON_AUTH_TOKEN'}
+    */
+    self.options.marathonHeaders = options.marathonHeaders || {};
+
     // Whether to emit a "connectionId" event
     self.options.enableConnectionEvent = options.enableConnectionEvent || false;
 
@@ -86,7 +93,7 @@ function MarathonEventBusClient (options) {
             }
         }
     });
-    
+
 }
 
 // Inherit from EventEmitter
@@ -101,7 +108,10 @@ MarathonEventBusClient.prototype.subscribe = function () {
         url = self.options.marathonProtocol + "://" + self.options.marathonHost + ":" + self.options.marathonPort+self.options.marathonUri;
 
     // Allow unauthorized HTTPS requests
-    let eventSourceInitDict = { rejectUnauthorized: false };
+    let eventSourceInitDict = {
+      self.options.marathonHeaders,
+      rejectUnauthorized: false
+    };
 
     // Create EventSource for Marathon /v2/events endpoint
     self.es = new EventSource(url, eventSourceInitDict);

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -25,7 +25,7 @@ function MarathonEventBusClient (options) {
       "pod_created_event","pod_updated_event", "pod_deleted_event","scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event", "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"
     ];
 
-    self.allowedHeaeders = [
+    self.allowedHeaders = [
       'Content-Type', 'Authorization'
     ];
 
@@ -38,7 +38,7 @@ function MarathonEventBusClient (options) {
     self.options.marathonUri = options.marathonUri || "/v2/events";
     /*
      You can add additionals headers
-     {'Authorization': 'token=MARATHON_AUTH_TOKEN', 'Content-Type': 'application/json'}
+     {'Authorization': 'token=ACCESS_TOKEN', 'Content-Type': 'application/json'}
     */
     self.options.marathonHeaders = options.marathonHeaders || {};
 
@@ -61,7 +61,7 @@ function MarathonEventBusClient (options) {
     if (options.marathonHeaders && Object.keys(options.marathonHeaders).length > 0) {
       self.options.marathonHeaders = {};
         Object.keys(options.marathonHeaders).forEach(function (key) {
-          if(self.allowedHeaeders.indexOf(key) > -1) {
+          if(self.allowedHeaders.indexOf(key) > -1) {
             self.options.marathonHeaders[key] = options.marathonHeaders[key];
           }
         });

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -36,12 +36,6 @@ function MarathonEventBusClient (options) {
     self.options.marathonPort = parseInt(options.marathonPort) || 8080;
     self.options.marathonProtocol = options.marathonProtocol || "http";
     self.options.marathonUri = options.marathonUri || "/v2/events";
-    /*
-     You can add additionals headers
-     {'Authorization': 'token=API_ACCESS_TOKEN', 'Content-Type': 'application/json'}
-    */
-    self.options.marathonHeaders = options.marathonHeaders || {};
-
     // Whether to emit a "connectionId" event
     self.options.enableConnectionEvent = options.enableConnectionEvent || false;
 
@@ -120,10 +114,11 @@ MarathonEventBusClient.prototype.subscribe = function () {
     let self = this,
         url = self.options.marathonProtocol + "://" + self.options.marathonHost + ":" + self.options.marathonPort+self.options.marathonUri;
 
-    // Allow unauthorized HTTPS requests
-    let eventSourceInitDict = self.options.marathonHeaders;
-
-    eventSourceInitDict.rejectUnauthorized = false;
+    // Allow unauthorized HTTPS requests and custome headers
+    let eventSourceInitDict = {
+      headers: self.options.marathonHeaders,
+      rejectUnauthorized: false,
+    };
 
     // Create EventSource for Marathon /v2/events endpoint
     self.es = new EventSource(url, eventSourceInitDict);

--- a/lib/MarathonEventBusClient.js
+++ b/lib/MarathonEventBusClient.js
@@ -22,8 +22,8 @@ function MarathonEventBusClient (options) {
 
     // See https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/core/event/Events.scala
     self.allowedEventTypes = [
-      "pod_created_event","pod_updated_event", "pod_deleted_event", "scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event",
-      "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"];
+      "pod_created_event","pod_updated_event", "pod_deleted_event","scheduler_registered_event", "scheduler_reregistered_event", "scheduler_disconnected_event", "subscribe_event", "unsubscribe_event", "event_stream_attached", "event_stream_detached", "add_health_check_event", "remove_health_check_event", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "group_change_success", "group_change_failed", "deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "app_terminated_event", "status_update_event", "instance_changed_event", "unknown_instance_terminated_event", "instance_health_changed_event", "framework_message_event"
+    ];
 
     self.options = {};
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -23,6 +23,7 @@ describe("MarathonEventBusClient tests", function() {
         expect(mebc.options.marathonHost).to.equal("master.mesos");
         expect(mebc.options.marathonPort).to.equal(8080);
         expect(mebc.options.marathonProtocol).to.equal("http");
+        expect(mebc.options.marathonHeaders).to.eql({});
     });
 
     describe("Using TestSSEServer", function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -23,7 +23,6 @@ describe("MarathonEventBusClient tests", function() {
         expect(mebc.options.marathonHost).to.equal("master.mesos");
         expect(mebc.options.marathonPort).to.equal(8080);
         expect(mebc.options.marathonProtocol).to.equal("http");
-        expect(mebc.options.marathonHeaders).to.eql({});
     });
 
     describe("Using TestSSEServer", function () {


### PR DESCRIPTION
Adding `marathonHeaders` to allow custom headers for the request this allow us to make request to the api outside the cluster or in development 